### PR TITLE
RPI_SYSTIMER_BASE address in part 3 of the tutorial

### DIFF
--- a/part-3/arm011/rpi-systimer.h
+++ b/part-3/arm011/rpi-systimer.h
@@ -6,8 +6,11 @@
 
 #include "rpi-base.h"
 
-#define RPI_SYSTIMER_BASE       0x20003000
-
+#ifdef RPI2
+	#define RPI_SYSTIMER_BASE       0x3f003000
+#else
+	#define RPI_SYSTIMER_BASE       0x20003000
+#endif
 
 typedef struct {
     volatile uint32_t control_status;

--- a/part-3/arm012/rpi-systimer.h
+++ b/part-3/arm012/rpi-systimer.h
@@ -6,8 +6,11 @@
 
 #include "rpi-base.h"
 
-#define RPI_SYSTIMER_BASE       0x20003000
-
+#ifdef RPI2
+	#define RPI_SYSTIMER_BASE       0x3f003000
+#else
+	#define RPI_SYSTIMER_BASE       0x20003000
+#endif
 
 typedef struct {
     volatile uint32_t control_status;


### PR DESCRIPTION
RPI_SYSTIMER_BASE should depend on platform type (variable RPI2).
