### PR TITLE
fixed setting of init nibble in function select gpio peripheral register

### DIFF
--- a/part-4/armc-013/armc-013.c
+++ b/part-4/armc-013/armc-013.c
@@ -27,7 +27,7 @@ void kernel_main( unsigned int r0, unsigned int r1, unsigned int atags )
 {
     /* Write 1 to the LED init nibble in the Function Select GPIO
        peripheral register to enable LED pin as an output */
-    RPI_GetGpio()->LED_GPFSEL |= LED_GPFBIT;
+    RPI_GetGpio()->LED_GPFSEL |= ( 1 << LED_GPFBIT);
 
     /* Enable the timer interrupt IRQ */
     RPI_GetIrqController()->Enable_Basic_IRQs = RPI_BASIC_ARM_TIMER_IRQ;

--- a/part-4/readme.md
+++ b/part-4/readme.md
@@ -596,7 +596,7 @@ part-4/armc-013/armc-013.c:
     {
         /* Write 1 to the LED init nibble in the Function Select GPIO
            peripheral register to enable LED pin as an output */
-        RPI_GetGpio()->LED_GPFSEL |= LED_GPFBIT;
+        RPI_GetGpio()->LED_GPFSEL |= ( 1 << LED_GPFBIT);
 
         /* Enable the timer interrupt IRQ */
         RPI_GetIrqController()->Enable_Basic_IRQs = RPI_BASIC_ARM_TIMER_IRQ;

--- a/part-5/armc-014/armc-014.c
+++ b/part-5/armc-014/armc-014.c
@@ -48,7 +48,7 @@ void kernel_main( unsigned int r0, unsigned int r1, unsigned int atags )
 
     /* Write 1 to the LED init nibble in the Function Select GPIO
        peripheral register to enable LED pin as an output */
-    RPI_GetGpio()->LED_GPFSEL |= LED_GPFBIT;
+    RPI_GetGpio()->LED_GPFSEL |= ( 1 << LED_GPFBIT);
 
     /* Enable the timer interrupt IRQ */
     RPI_GetIrqController()->Enable_Basic_IRQs = RPI_BASIC_ARM_TIMER_IRQ;

--- a/part-5/armc-015/armc-015.c
+++ b/part-5/armc-015/armc-015.c
@@ -66,7 +66,7 @@ void kernel_main( unsigned int r0, unsigned int r1, unsigned int atags )
 
     /* Write 1 to the LED init nibble in the Function Select GPIO
        peripheral register to enable LED pin as an output */
-    RPI_GetGpio()->LED_GPFSEL |= LED_GPFBIT;
+    RPI_GetGpio()->LED_GPFSEL |= ( 1 << LED_GPFBIT);
 
     /* Enable the timer interrupt IRQ */
     RPI_GetIrqController()->Enable_Basic_IRQs = RPI_BASIC_ARM_TIMER_IRQ;

--- a/part-5/armc-016/armc-016.c
+++ b/part-5/armc-016/armc-016.c
@@ -66,7 +66,7 @@ void kernel_main( unsigned int r0, unsigned int r1, unsigned int atags )
 
     /* Write 1 to the LED init nibble in the Function Select GPIO
        peripheral register to enable LED pin as an output */
-    RPI_GetGpio()->LED_GPFSEL |= LED_GPFBIT;
+    RPI_GetGpio()->LED_GPFSEL |= ( 1 << LED_GPFBIT);
 
     /* Enable the timer interrupt IRQ */
     RPI_GetIrqController()->Enable_Basic_IRQs = RPI_BASIC_ARM_TIMER_IRQ;


### PR DESCRIPTION
When replacing LED_GPFBIT and LED_GPIO_BIT i noticed the LED_GPFSEL register does not get set properly.
