### PR TITLE
Fix cmake deprecation warning

### DIFF
--- a/compiler/cmake-toolchains/toolchain-arm-none-eabi-rpi0.cmake
+++ b/compiler/cmake-toolchains/toolchain-arm-none-eabi-rpi0.cmake
@@ -8,8 +8,6 @@
 
 # A CMake toolchain file so we can cross-compile for the Rapsberry-Pi bare-metal
 
-include(CMakeForceCompiler)
-
 # usage
 # cmake -DCMAKE_TOOLCHAIN_FILE=../toolchain-arm-none-eabi.cmake ../
 
@@ -31,8 +29,12 @@ set( CROSS_COMPILE arm-none-eabi- )
 # attempt to build a simple test program as this will fail without us using
 # the -nostartfiles option on the command line
 
-CMAKE_FORCE_C_COMPILER( "${TC_PATH}${CROSS_COMPILE}gcc" GNU )
-SET( CMAKE_ASM_COMPILER "${TC_PATH}${CROSS_COMPILE}gcc" )
+set( CMAKE_C_COMPILER ${CROSS_COMPILE}gcc )
+set( CMAKE_ASM_COMPILER ${CROSS_COMPILE}gcc )
+
+# Because the cross-compiler cannot directly generate a binary without complaining, just test
+# compiling a static library instead of an executable program
+set( CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY )
 
 # We must set the OBJCOPY setting into cache so that it's available to the
 # whole project. Otherwise, this does not get set into the CACHE and therefore

--- a/compiler/cmake-toolchains/toolchain-arm-none-eabi-rpi0.cmake
+++ b/compiler/cmake-toolchains/toolchain-arm-none-eabi-rpi0.cmake
@@ -29,8 +29,8 @@ set( CROSS_COMPILE arm-none-eabi- )
 # attempt to build a simple test program as this will fail without us using
 # the -nostartfiles option on the command line
 
-set( CMAKE_C_COMPILER ${CROSS_COMPILE}gcc )
-set( CMAKE_ASM_COMPILER ${CROSS_COMPILE}gcc )
+set( CMAKE_C_COMPILER "${TC_PATH}${CROSS_COMPILE}gcc" )
+set( CMAKE_ASM_COMPILER "${TC_PATH}${CROSS_COMPILE}gcc" )
 
 # Because the cross-compiler cannot directly generate a binary without complaining, just test
 # compiling a static library instead of an executable program

--- a/compiler/cmake-toolchains/toolchain-arm-none-eabi-rpi1.cmake
+++ b/compiler/cmake-toolchains/toolchain-arm-none-eabi-rpi1.cmake
@@ -8,8 +8,6 @@
 
 # A CMake toolchain file so we can cross-compile for the Rapsberry-Pi bare-metal
 
-include(CMakeForceCompiler)
-
 # usage
 # cmake -DCMAKE_TOOLCHAIN_FILE=../toolchain-arm-none-eabi.cmake ../
 
@@ -30,8 +28,13 @@ set( CROSS_COMPILE arm-none-eabi- )
 # specify the cross compiler. We force the compiler so that CMake doesn't
 # attempt to build a simple test program as this will fail without us using
 # the -nostartfiles option on the command line
-CMAKE_FORCE_C_COMPILER( "${TC_PATH}${CROSS_COMPILE}gcc" GNU )
-SET( CMAKE_ASM_COMPILER "${TC_PATH}${CROSS_COMPILE}gcc" )
+
+set( CMAKE_C_COMPILER "${TC_PATH}${CROSS_COMPILE}gcc" )
+set( CMAKE_ASM_COMPILER "${TC_PATH}${CROSS_COMPILE}gcc" )
+
+# Because the cross-compiler cannot directly generate a binary without complaining, just test
+# compiling a static library instead of an executable program
+set( CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY )
 
 # We must set the OBJCOPY setting into cache so that it's available to the
 # whole project. Otherwise, this does not get set into the CACHE and therefore

--- a/compiler/cmake-toolchains/toolchain-arm-none-eabi-rpi1bp.cmake
+++ b/compiler/cmake-toolchains/toolchain-arm-none-eabi-rpi1bp.cmake
@@ -8,8 +8,6 @@
 
 # A CMake toolchain file so we can cross-compile for the Rapsberry-Pi bare-metal
 
-include(CMakeForceCompiler)
-
 # usage
 # cmake -DCMAKE_TOOLCHAIN_FILE=../toolchain-arm-none-eabi.cmake ../
 
@@ -30,8 +28,13 @@ set( CROSS_COMPILE arm-none-eabi- )
 # specify the cross compiler. We force the compiler so that CMake doesn't
 # attempt to build a simple test program as this will fail without us using
 # the -nostartfiles option on the command line
-CMAKE_FORCE_C_COMPILER( "${TC_PATH}${CROSS_COMPILE}gcc" GNU )
-SET( CMAKE_ASM_COMPILER "${TC_PATH}${CROSS_COMPILE}gcc" )
+
+set( CMAKE_C_COMPILER "${TC_PATH}${CROSS_COMPILE}gcc" )
+set( CMAKE_ASM_COMPILER "${TC_PATH}${CROSS_COMPILE}gcc" )
+
+# Because the cross-compiler cannot directly generate a binary without complaining, just test
+# compiling a static library instead of an executable program
+set( CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY )
 
 # We must set the OBJCOPY setting into cache so that it's available to the
 # whole project. Otherwise, this does not get set into the CACHE and therefore

--- a/compiler/cmake-toolchains/toolchain-arm-none-eabi-rpi2.cmake
+++ b/compiler/cmake-toolchains/toolchain-arm-none-eabi-rpi2.cmake
@@ -8,8 +8,6 @@
 
 # A CMake toolchain file so we can cross-compile for the Rapsberry-Pi bare-metal
 
-include(CMakeForceCompiler)
-
 # usage
 # cmake -DCMAKE_TOOLCHAIN_FILE=../toolchain-arm-none-eabi.cmake ../
 
@@ -30,8 +28,13 @@ set( CROSS_COMPILE arm-none-eabi- )
 # specify the cross compiler. We force the compiler so that CMake doesn't
 # attempt to build a simple test program as this will fail without us using
 # the -nostartfiles option on the command line
-CMAKE_FORCE_C_COMPILER( "${TC_PATH}${CROSS_COMPILE}gcc" GNU )
-SET( CMAKE_ASM_COMPILER "${TC_PATH}${CROSS_COMPILE}gcc" )
+
+set( CMAKE_C_COMPILER "${TC_PATH}${CROSS_COMPILE}gcc" )
+set( CMAKE_ASM_COMPILER "${TC_PATH}${CROSS_COMPILE}gcc" )
+
+# Because the cross-compiler cannot directly generate a binary without complaining, just test
+# compiling a static library instead of an executable program
+set( CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY )
 
 # We must set the OBJCOPY setting into cache so that it's available to the
 # whole project. Otherwise, this does not get set into the CACHE and therefore

--- a/compiler/cmake-toolchains/toolchain-arm-none-eabi-rpi3.cmake
+++ b/compiler/cmake-toolchains/toolchain-arm-none-eabi-rpi3.cmake
@@ -8,8 +8,6 @@
 
 # A CMake toolchain file so we can cross-compile for the Rapsberry-Pi bare-metal
 
-include(CMakeForceCompiler)
-
 # usage
 # cmake -DCMAKE_TOOLCHAIN_FILE=../toolchain-arm-none-eabi.cmake ../
 
@@ -30,8 +28,13 @@ set( CROSS_COMPILE arm-none-eabi- )
 # specify the cross compiler. We force the compiler so that CMake doesn't
 # attempt to build a simple test program as this will fail without us using
 # the -nostartfiles option on the command line
-CMAKE_FORCE_C_COMPILER( "${TC_PATH}${CROSS_COMPILE}gcc" GNU )
-SET( CMAKE_ASM_COMPILER "${TC_PATH}${CROSS_COMPILE}gcc" )
+
+set( CMAKE_C_COMPILER "${TC_PATH}${CROSS_COMPILE}gcc" )
+set( CMAKE_ASM_COMPILER "${TC_PATH}${CROSS_COMPILE}gcc" )
+
+# Because the cross-compiler cannot directly generate a binary without complaining, just test
+# compiling a static library instead of an executable program
+set( CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY )
 
 # We must set the OBJCOPY setting into cache so that it's available to the
 # whole project. Otherwise, this does not get set into the CACHE and therefore

--- a/compiler/cmake-toolchains/toolchain-arm-none-eabi-rpi3bp.cmake
+++ b/compiler/cmake-toolchains/toolchain-arm-none-eabi-rpi3bp.cmake
@@ -8,8 +8,6 @@
 
 # A CMake toolchain file so we can cross-compile for the Rapsberry-Pi bare-metal
 
-include(CMakeForceCompiler)
-
 # usage
 # cmake -DCMAKE_TOOLCHAIN_FILE=../toolchain-arm-none-eabi.cmake ../
 
@@ -30,8 +28,13 @@ set( CROSS_COMPILE arm-none-eabi- )
 # specify the cross compiler. We force the compiler so that CMake doesn't
 # attempt to build a simple test program as this will fail without us using
 # the -nostartfiles option on the command line
-CMAKE_FORCE_C_COMPILER( "${TC_PATH}${CROSS_COMPILE}gcc" GNU )
-SET( CMAKE_ASM_COMPILER "${TC_PATH}${CROSS_COMPILE}gcc" )
+
+set( CMAKE_C_COMPILER "${TC_PATH}${CROSS_COMPILE}gcc" )
+set( CMAKE_ASM_COMPILER "${TC_PATH}${CROSS_COMPILE}gcc" )
+
+# Because the cross-compiler cannot directly generate a binary without complaining, just test
+# compiling a static library instead of an executable program
+set( CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY )
 
 # We must set the OBJCOPY setting into cache so that it's available to the
 # whole project. Otherwise, this does not get set into the CACHE and therefore

--- a/compiler/cmake-toolchains/toolchain-arm-none-eabi-rpi4.cmake
+++ b/compiler/cmake-toolchains/toolchain-arm-none-eabi-rpi4.cmake
@@ -8,8 +8,6 @@
 
 # A CMake toolchain file so we can cross-compile for the Rapsberry-Pi bare-metal
 
-include(CMakeForceCompiler)
-
 # usage
 # cmake -DCMAKE_TOOLCHAIN_FILE=../toolchain-arm-none-eabi.cmake ../
 
@@ -30,8 +28,13 @@ set( CROSS_COMPILE arm-none-eabi- )
 # specify the cross compiler. We force the compiler so that CMake doesn't
 # attempt to build a simple test program as this will fail without us using
 # the -nostartfiles option on the command line
-CMAKE_FORCE_C_COMPILER( "${TC_PATH}${CROSS_COMPILE}gcc" GNU )
-SET( CMAKE_ASM_COMPILER "${TC_PATH}${CROSS_COMPILE}gcc" )
+
+set( CMAKE_C_COMPILER "${TC_PATH}${CROSS_COMPILE}gcc" )
+set( CMAKE_ASM_COMPILER "${TC_PATH}${CROSS_COMPILE}gcc" )
+
+# Because the cross-compiler cannot directly generate a binary without complaining, just test
+# compiling a static library instead of an executable program
+set( CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY )
 
 # We must set the OBJCOPY setting into cache so that it's available to the
 # whole project. Otherwise, this does not get set into the CACHE and therefore


### PR DESCRIPTION
Fixes #35 - CMake has deprecated forcing the C Compiler setting.

To fix we change to just setting the C Compiler setting and then tell CMake to only test the compiler by building a static library instead of a working executable.