### PR TITLE
Fix rpi4 cmake

### DIFF
--- a/compiler/cmake-toolchains/toolchain-arm-none-eabi-rpi3.cmake
+++ b/compiler/cmake-toolchains/toolchain-arm-none-eabi-rpi3.cmake
@@ -53,3 +53,4 @@ set( CMAKE_ASM_FLAGS "${CMAKE_C_FLAGS}" CACHE STRING "" )
 
 # Add the raspberry-pi 3 definition so conditional compilation works
 add_definitions( -DRPI3=1 )
+set( BOARD rpi3 )

--- a/compiler/cmake-toolchains/toolchain-arm-none-eabi-rpi4.cmake
+++ b/compiler/cmake-toolchains/toolchain-arm-none-eabi-rpi4.cmake
@@ -53,3 +53,4 @@ set( CMAKE_ASM_FLAGS "${CMAKE_C_FLAGS}" CACHE STRING "" )
 
 # Add the raspberry-pi 4 definition so conditional compilation works
 add_definitions( -DRPI4=1 )
+set( BOARD rpi4 )


### PR DESCRIPTION
Fixes #42 as well as fixing RPI3 board compilation which is also broken in the same manor