### PR TITLE
docs: fix simple typo, slighly -> slightly

### DIFF
--- a/part-5/readme.md
+++ b/part-5/readme.md
@@ -1422,7 +1422,7 @@ pretty rubbish.
 
 - `RPI0` improves a reasonable amount from a 300MHz increase in ARM frequency and the L1 Cache
 - `RPI1B+` improves slightly from just the L1 Cache
-- `RPI2` improves slighly from 300MHz increase in ARM frequency and the L1 Cache
+- `RPI2` improves slightly from 300MHz increase in ARM frequency and the L1 Cache
 - `RPI3B+` improves a reasonable amount with 600MHz increase in ARM frequency and the L1 Cache
 - `RPI4` improves a reasonable amount with the largest increase of 900MHz increase in ARM Frequency
   and the L1 Cache


### PR DESCRIPTION
There is a small typo in part-5/readme.md.

Should read `slightly` rather than `slighly`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md